### PR TITLE
# Improve Github-Workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Build OpenEMS
 on: [push]
 jobs:
-  build-code:
+  build-java:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -19,6 +19,8 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
+            ~/.gradle/native
+            ~/.gradle/notifications
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle-
 
@@ -27,63 +29,100 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '14'
-
-      - name: Setup Cache for Node.js
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: ${{ runner.os }}-node-
+          restore-keys: ${{ runner.os }}-maven-
 
       - name: Build all Java packages
-        run: ./gradlew build
+        run: ./gradlew build --info
 
-      - name: Resolve OpenEMS Backend bundles
-        run: ./gradlew resolve.BackendApp
+      - name: Resolve OpenEMS bundles
+        run: ./gradlew resolve
 
       - name: Validate BackendApp.bndrun
         run: git diff --exit-code io.openems.backend.application/BackendApp.bndrun
 
-      - name: Resolve OpenEMS Edge bundles
-        run: ./gradlew resolve.EdgeApp
-
       - name: Validate EdgeApp.bndrun
         run: git diff --exit-code io.openems.edge.application/EdgeApp.bndrun
+
+      #
+      # Is this a Tag? Prepare release assets
+      #
+      - name: Prepare Edge+Backend assets
+        if: startsWith(github.ref, 'refs/tags/')
+        run: ./gradlew buildEdge buildBackend
+
+      - name: Save build-artifacts
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-artifacts
+          path: |
+            build/openems-edge.jar
+            build/openems-backend.jar
+
+  build-ui:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - name: Setup Cache for Node.js
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.npm
+            ~/.ng
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-node-
 
       - name: Build OpenEMS UI
         run: |
           cd ui
+          npm install 
           npm ci --prefer-offline --cache ~/.npm
+          node_modules/.bin/ng config cli.cache.path "~/.ng"
           node_modules/.bin/ng build -c "openems,openems-edge-prod,prod"
           node_modules/.bin/ng lint
-
+          
       #
-      # Is this a Tag? Prepare release assets and create a draft release
+      # Is this a Tag? Prepare release assets
       #
-      - name: Prepare Edge+Backend assets
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          ./gradlew buildEdge buildBackend
-
       - name: Prepare UI asset
         if: startsWith(github.ref, 'refs/tags/')
-        uses: edgarrc/action-7z@v1
-        with:
-          args: 7z a openems-ui.zip ./ui/target/*
-
-      - name: Create draft Release
+        run: |
+          mkdir build
+          cd ui/target
+          zip -r ../../build/openems-ui.zip ./*
+          
+      - name: Save build-artifacts
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v1
+        uses: actions/upload-artifact@v3
         with:
-          draft: true
-          files: |
-            build/openems-edge.jar
-            build/openems-backend.jar
-            openems-ui.zip
+          name: build-artifacts
+          path: build/openems-ui.zip
+
+  #
+  # Is this a Tag? Create a draft release
+  #
+  release:
+    runs-on: ubuntu-latest
+    needs: [build-java, build-ui]
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:    
+    - name: Load build-artifacts
+      uses: actions/download-artifact@v3
+      with:
+        name: build-artifacts
+        path: build
+    
+    - name: Create draft Release
+      uses: softprops/action-gh-release@v1
+      with:
+        draft: true
+        files: |
+          build/openems-edge.jar
+          build/openems-backend.jar
+          build/openems-ui.zip

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,18 @@ jobs:
   build-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
+      - name: Setup Cache for Java/Gradle
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.gradle/native
+            ~/.gradle/notifications
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-
 
       - name: Build Javadocs
         run: ./gradlew buildAggregatedJavadocs --continue

--- a/build.gradle
+++ b/build.gradle
@@ -86,7 +86,7 @@ task buildEdge() {
 		copy {
 			from file("io.openems.edge.application/generated/distributions/executable/EdgeApp.jar")
 			into file("${buildDir}")
-			rename ("EdgeApp.jar", "openems.jar")
+			rename ("EdgeApp.jar", "openems-edge.jar")
 		}
 	}
 }


### PR DESCRIPTION
## buld.gradle
* openems.jar -> openems-edge.jar

## build.yml
* split build-code into build-java, build-ui and release
* run build-java and build-ui parallel
* build-java : extend gradle cache
* build-ui :  node-14 -> node-16
* build-ui : add ng cache
* build-ui : use 'zip' to pack ui instead of '7z'

## docs.yml
* actions/checkout use 'v3' instead of 'V2'
* use gradle cache